### PR TITLE
Added new built-in Slot Types for Europe

### DIFF
--- a/src/built-in-slots-map.js
+++ b/src/built-in-slots-map.js
@@ -8,5 +8,14 @@ module.exports = {
     'USCity': 'AMAZON.US_CITY',
     'USFirstname': 'AMAZON.US_FIRST_NAME',
     'USState': 'AMAZON.US_STATE',
-    'Literal': 'AMAZON.LITERAL',
+    'ATCity': 'AMAZON.AT_CITY',
+    'ATRegion': 'AMAZON.AT_REGION',
+    'DECity': 'AMAZON.DE_CITY',
+    'DEFirstname': 'AMAZON.DE_FIRST_NAME',
+    'DERegion': 'AMAZON.DE_REGION',
+    'GBCity': 'AMAZON.GB_CITY',
+    'GBFirstname': 'AMAZON.GB_FIRST_NAME',
+    'GBRegion': 'AMAZON.GB_REGION',
+    'EUCity': 'AMAZON.EUROPE_CITY',
+    'Literal': 'AMAZON.LITERAL'
 };


### PR DESCRIPTION
Added new Slot Types for Europe, Great Britain, Germany and Austria.
See [https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interaction-model-reference#slot-types](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interaction-model-reference#slot-types)