### PR TITLE
Create sophisticated request

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,31 @@ exports.handler = (event, context, callback) => {
 
 Each application should be unit-tested. We are exposing simple API helping you to create sample Alexa requests for testing and debugging.
 
+```javascript
+alexia.createRequest({
+  type: 'IntentRequest',
+  name: 'UnknownIntent',
+  slots: {},
+  attrs: {},
+  appId: 'amzn1.echo-sdk-123456',
+  sessionId: 'SessionId.357a6s7',
+  userId: 'amzn1.account.abc123',
+  requestId: 'EdwRequestId.abc123456',
+  timestamp: '2016-06-16T14:38:46Z',
+  locale: 'en-US',
+  new: false
+});
+```
+
+All the properties optional and defaults to the values you see in the example above. Sample usage:
+
+```javascript
+alexia.createRequest({type: 'IntentRequest', name: 'HelloIntent', slots: ..., attrs: ...});
+alexia.createIntentRequest('HelloIntent', slots, attrs, isNew, appId); // Shorter version - does not support all of the properties
+```
+
+Before writing unit tests make sure to install all the dependencies. In our example we will be using mocha and chai with expect.
+
 ```bash
 npm install mocha chai expect --save-dev
 ```

--- a/src/alexia.js
+++ b/src/alexia.js
@@ -3,8 +3,25 @@ const createApp = require('./create-app');
 const createRequest = require('./create-request');
 
 module.exports = {
-  createApp: createApp,
-  createLaunchRequest: createRequest.launchRequest,
-  createSessionEndedRequest: createRequest.sessionEndedRequest,
-  createIntentRequest: createRequest.intentRequest
+  createApp,
+  createRequest,
+
+  createLaunchRequest: (attrs, appId) => {
+    return createRequest({type: 'LaunchRequest', new: true, attrs, appId});
+  },
+
+  createSessionEndedRequest: (attrs, appId) => {
+    return createRequest({type: 'SessionEndedRequest', new: false, attrs, appId});
+  },
+
+  createIntentRequest: (name, slots, attrs, isNew, appId) => {
+    return createRequest({
+      type: 'IntentRequest',
+      name,
+      slots,
+      new: isNew,
+      attrs,
+      appId
+    });
+  }
 };

--- a/src/create-request.js
+++ b/src/create-request.js
@@ -2,73 +2,72 @@
 const _ = require('lodash');
 
 /**
- * Creates simple Alexa request
+ * Creates Alexa request
+ * @param [options]
+ * @param [options.type]
+ * @param [options.name]
+ * @param [options.slots]
+ * @param [options.attrs]
+ * @param [options.appId]
+ * @param [options.sessionid]
+ * @param [options.userId]
+ * @param [options.requestId]
+ * @param [options.timestamp]
+ * @param [options.locale]
+ * @param [options.new]
  */
-const requestBuilder = (requestType, intent, isNew, attrs, appId) => {
+module.exports = options => {
 
-  const request = {
-    session: {
-      attributes: attrs || {},
-      sessionId: 'SessionId.357a6s7',
-      application: {
-        applicationId: appId || 'amzn1.echo-sdk-123456'
-      },
-      user: {
-        userId: 'amzn1.account.abc123'
-      },
-      new: isNew || false
-    },
-    request: {
-      type: requestType,
-      requestId: 'EdwRequestId.abc123456',
-      timestamp: '2016-06-16T14:38:46Z',
-      intent: intent
-    }
-  };
+  // Assign default request options
+  options = Object.assign({
+    type: 'IntentRequest',
+    name: 'UnknownIntent',
+    slots: {},
+    attrs: {},
+    appId: 'amzn1.echo-sdk-123456',
+    sessionId: 'SessionId.357a6s7',
+    userId: 'amzn1.account.abc123',
+    requestId: 'EdwRequestId.abc123456',
+    timestamp: '2016-06-16T14:38:46Z',
+    locale: 'en-US',
+    new: false
+  }, options);
 
-  return request;
-};
+  let intent;
 
-module.exports = {
-  /**
-   * Creates LaunchRequest
-   * @param {Object} attrs - Session attributes
-   * @param {String} [appId] - Application id
-   */
-  launchRequest: (attrs, appId) => {
-    return requestBuilder('LaunchRequest', null, true, attrs, appId);
-  },
-
-  /**
-   * Creates SessionEndedRequest
-   * @param {Object} attrs - Session attributes
-   * @param {String} [appId] - Application id
-   */
-  sessionEndedRequest: (attrs, appId) => {
-    return requestBuilder('SessionEndedRequest', null, false, attrs, appId);
-  },
-
-  /**
-   * Creates IntentRequest
-   * @param {String} name - Name of the intent to be invoked
-   * @param {Object} [slots] - Slots in simplified key:value schema. Defaults to {}
-   * @param {Object} [attrs] - Session attributes. Defaults to {}
-   * @param {boolean} [isNew] - Whether session is new. Defaults to false
-   * @param {String} [appId] - Application id
-   */
-  intentRequest: (name, slots, attrs, isNew, appId) => {
-
+  if (options.type === 'IntentRequest') {
     // Transform slots from minimal schema into slot schema sent by Amazon
-    let transformedSlots = _.transform(slots, (result, key, value) => {
+    const transformedSlots = _.transform(options.slots, (result, key, value) => {
       result[key] = {
         name: value,
         value: key
       };
     }, {});
 
-    return requestBuilder('IntentRequest', {
-      name: name,
-      slots: slots ? transformedSlots : undefined
-    }, isNew, attrs, appId);
+    intent = {
+      name: options.name,
+      slots: options.slots ? transformedSlots : undefined
+    };
   }
+
+  return {
+    session: {
+      attributes: options.attrs || {},
+      sessionId: options.sessionId,
+      application: {
+        applicationId: options.appId
+      },
+      user: {
+        userId: options.userId
+      },
+      new: options.new
+    },
+    request: {
+      type: options.type,
+      requestId: options.requestId,
+      timestamp: options.timestamp,
+      intent: intent,
+      locale: options.locale
+    }
+  };
 };

--- a/test/actions.spec.js
+++ b/test/actions.spec.js
@@ -1,13 +1,13 @@
 'use strict';
 const expect = require('chai').expect;
 const app = require('./test-apps/actions-app');
-const createRequest = require('../src/create-request');
+const alexia = require('..');
 
 describe('action app handler', () => {
   let attrs;
 
   it('should handle IntentA and remember previousIntent', () => {
-    const request = createRequest.intentRequest('IntentA', null, null, true);
+    const request = alexia.createIntentRequest('IntentA', null, null, true);
     app.handle(request, (response) => {
       attrs = response.sessionAttributes;
       expect(response).to.be.defined;
@@ -16,7 +16,7 @@ describe('action app handler', () => {
   });
 
   it('should handle IntentB and remember previousIntent', () => {
-    const request = createRequest.intentRequest('IntentB', null, attrs);
+    const request = alexia.createIntentRequest('IntentB', null, attrs);
     app.handle(request, (response) => {
       expect(response).to.be.defined;
       expect(response.sessionAttributes.previousIntent).to.equal('IntentB');
@@ -24,7 +24,7 @@ describe('action app handler', () => {
   });
 
   it('should not handle nonexistent intent and throw error', () => {
-    const request = createRequest.intentRequest('IntentZ', null, attrs);
+    const request = alexia.createIntentRequest('IntentZ', null, attrs);
     try {
       app.handle(request);
     } catch (e) {
@@ -33,14 +33,14 @@ describe('action app handler', () => {
   });
 
   it('should not handle IntentB again', () => {
-    const request = createRequest.intentRequest('IntentB', null, attrs);
+    const request = alexia.createIntentRequest('IntentB', null, attrs);
     app.handle(request, (response) => {
       expect(response.response.outputSpeech.text).to.equal('Sorry, your command is invalid');
     });
   });
 
   it('should not handle IntentB again with defaultActionFail', () => {
-    const request = createRequest.intentRequest('IntentB', null, attrs);
+    const request = alexia.createIntentRequest('IntentB', null, attrs);
     app.defaultActionFail(() => 'Sry bye');
     app.handle(request, (response) => {
       expect(response.response.outputSpeech.text).to.equal('Sry bye');
@@ -48,21 +48,21 @@ describe('action app handler', () => {
   });
 
   it('should not handle IntentB -> IntentC', () => {
-    const request = createRequest.intentRequest('IntentC', null, attrs);
+    const request = alexia.createIntentRequest('IntentC', null, attrs);
     app.handle(request, (response) => {
       expect(response.response.outputSpeech.text).to.equal('Could not handle request');
     });
   });
 
   it('should not handle IntentB -> IntentD', () => {
-    const request = createRequest.intentRequest('IntentD', null, attrs);
+    const request = alexia.createIntentRequest('IntentD', null, attrs);
     app.handle(request, (response) => {
       expect(response.response.outputSpeech.text).to.equal('Sry bye');
     });
   });
 
   it('should handle async IntentE with session attributes', () => {
-    const request = createRequest.intentRequest('IntentE', null, attrs);
+    const request = alexia.createIntentRequest('IntentE', null, attrs);
     app.handle(request, (response) => {
       expect(response.sessionAttributes).to.deep.equal({
         previousIntent: 'IntentE',


### PR DESCRIPTION
- exposed new API: `alexia.createRequest(options)`. Example:
```javascript
alexia.createRequest({
  type: 'IntentRequest',
  name: 'UnknownIntent',
  slots: {},
  attrs: {},
  appId: 'amzn1.echo-sdk-123456',
  sessionId: 'SessionId.357a6s7',
  userId: 'amzn1.account.abc123',
  requestId: 'EdwRequestId.abc123456',
  timestamp: '2016-06-16T14:38:46Z',
  locale: 'en-US',
  new: false
});
```
- previous create-request API is unchanged