### PR TITLE
Added more control on setting previousIntent value

### DIFF
--- a/test/actions.spec.js
+++ b/test/actions.spec.js
@@ -6,20 +6,23 @@ const alexia = require('..');
 describe('action app handler', () => {
   let attrs;
 
-  it('should handle IntentA and remember previousIntent', () => {
+  it('should handle IntentA and remember previousIntent', (done) => {
     const request = alexia.createIntentRequest('IntentA', null, null, true);
     app.handle(request, (response) => {
       attrs = response.sessionAttributes;
       expect(response).to.be.defined;
       expect(response.sessionAttributes.previousIntent).to.equal('IntentA');
+      done();
     });
   });
 
-  it('should handle IntentB and remember previousIntent', () => {
+  it('should handle IntentB and remember previousIntent', (done) => {
+    // console.log(attrs)
     const request = alexia.createIntentRequest('IntentB', null, attrs);
     app.handle(request, (response) => {
       expect(response).to.be.defined;
       expect(response.sessionAttributes.previousIntent).to.equal('IntentB');
+      done();
     });
   });
 
@@ -32,42 +35,82 @@ describe('action app handler', () => {
     }
   });
 
-  it('should not handle IntentB again', () => {
+  it('should not handle IntentB again', (done) => {
     const request = alexia.createIntentRequest('IntentB', null, attrs);
     app.handle(request, (response) => {
       expect(response.response.outputSpeech.text).to.equal('Sorry, your command is invalid');
+      done();
     });
   });
 
-  it('should not handle IntentB again with defaultActionFail', () => {
+  it('should not handle IntentB again with defaultActionFail', (done) => {
     const request = alexia.createIntentRequest('IntentB', null, attrs);
     app.defaultActionFail(() => 'Sry bye');
     app.handle(request, (response) => {
       expect(response.response.outputSpeech.text).to.equal('Sry bye');
+      done();
     });
   });
 
-  it('should not handle IntentB -> IntentC', () => {
+  it('should not handle IntentB -> IntentC', (done) => {
     const request = alexia.createIntentRequest('IntentC', null, attrs);
     app.handle(request, (response) => {
       expect(response.response.outputSpeech.text).to.equal('Could not handle request');
+      done();
     });
   });
 
-  it('should not handle IntentB -> IntentD', () => {
+  it('should not handle IntentB -> IntentD', (done) => {
     const request = alexia.createIntentRequest('IntentD', null, attrs);
     app.handle(request, (response) => {
       expect(response.response.outputSpeech.text).to.equal('Sry bye');
+      done();
     });
   });
 
-  it('should handle async IntentE with session attributes', () => {
+  it('should handle async IntentE with session attributes', (done) => {
     const request = alexia.createIntentRequest('IntentE', null, attrs);
     app.handle(request, (response) => {
       expect(response.sessionAttributes).to.deep.equal({
         previousIntent: 'IntentE',
         foo: true
       });
+      done();
+    });
+  });
+
+  it('should handle Intent and not update previousIntent if responseObject.error is true', (done) => {
+    const app2 = alexia.createApp();
+    app2.intent('Intent', () => {
+      return {
+        text: 'Some error occured',
+        error: true
+      };
+    });
+    const anotherAttrs = {
+      previousIntent: 'SomeIntent'
+    };
+    const request = alexia.createIntentRequest('Intent', null, anotherAttrs);
+    app2.handle(request, (response) => {
+      expect(response.sessionAttributes.previousIntent).to.equal('SomeIntent');
+      done();
+    });
+  });
+
+  it('should handle Intent and override previousIntent', (done) => {
+    const app2 = alexia.createApp();
+    app2.intent('Intent', () => {
+      return {
+        text: 'Hello, World',
+        attrs: {
+          previousIntent: 'MyCustomValue'
+        }
+      };
+    });
+    const request = alexia.createIntentRequest('Intent');
+    app2.handle(request, (response) => {
+      expect(response.sessionAttributes.previousIntent).to.equal('MyCustomValue');
+      done();
     });
   });
 });

--- a/test/contacts.spec.js
+++ b/test/contacts.spec.js
@@ -5,31 +5,35 @@ const alexia = require('..');
 
 describe('action app handler', () => {
 
-  it('should handle OpenContactList -> NewContact and return  correct outputSpeech', () => {
+  it('should handle OpenContactList -> NewContact and return  correct outputSpeech', (done) => {
     const request = alexia.createIntentRequest('NewContact', null, {previousIntent: 'OpenContactList'});
     app.handle(request, (response) => {
       expect(response.response.outputSpeech.text).to.equal('Please insert value for name or phone number of contact.');
+      done();
     });
   });
 
-  it('should handle NewContact -> SetName and return  correct outputSpeech', () => {
+  it('should handle NewContact -> SetName and return  correct outputSpeech', (done) => {
     const request = alexia.createIntentRequest('SetName', null, {previousIntent: 'NewContact'});
     app.handle(request, (response) => {
       expect(response.response.outputSpeech.text).to.equal('Name was saved.');
+      done();
     });
   });
 
-  it('should handle SetName -> CloseContactList and return  correct outputSpeech', () => {
+  it('should handle SetName -> CloseContactList and return  correct outputSpeech', (done) => {
     const request = alexia.createIntentRequest('CloseContactList', null, {previousIntent: 'SetName'});
     app.handle(request, (response) => {
       expect(response.response.outputSpeech.text).to.equal('See you next time.');
+      done();
     });
   });
 
-  it('should not handle OpenContactList -> SetName and return  correct outputSpeech', () => {
+  it('should not handle OpenContactList -> SetName and return  correct outputSpeech', (done) => {
     const request = alexia.createIntentRequest('SetName', null, {previousIntent: 'OpenContactList'});
     app.handle(request, (response) => {
       expect(response.response.outputSpeech.text).to.equal('Sorry, your command is invalid');
+      done();
     });
   });
 


### PR DESCRIPTION
- Added more control over previousIntent value
- By setting the `responseObject.error` to `true` keeps the previous value of `previousIntent`
- `responseObject.attrs.previousIntent` overrides the `previousIntent` to the specified value
- Use this to avoid setting previousIntent to the current intent in action flow on error